### PR TITLE
Refactor RawLang core: shared parser, per-language emitters, CLI flow, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,177 @@
 # RawLang
-RawLang is a user-friendly compiler that translates literal English to programming languages like Python, Javascript, GoLang, Rust code. With RawLang, you can write code using familiar English words and phrases.
- 
------
-You work on Building Logic and writing English paragraphs for the coding part RawLang takes care of it; no Vim needed for ultimate productivity.
 
-## Features
-- Write code using English-like syntax
-- Write continuous paragraphs without the need for indentation or code formatting.
-- No need to strain your fingers by typing random symbols; at most, use one full stop per paragraph.
-- Suitable for Rapid prototyping, scripting, automation, and educational purposes
-- Write in different programming languages
+RawLang is a lightweight source-to-source transpiler that converts readable, English-like instructions into code for:
 
-## Getting Started
-To get started with RawLang, simply clone the repository and follow the instructions.
-
-```
-C:\RawLang>python main.py {file location}
-For example:
-C:\RawLang>python main.py ./codeDir/english_code.txt
-
-```
-
-## Example 
-Write something like this in your 'english_code.txt' file:
-``` RawLang
-Language should be python
-
-make name and age with values "RawLang" 19.
-create function calculate with parameters x , y and z which assign x + y - z to result then return result
-create function print_message with parameters name and age which prints "Hello" + name
-print "Your age is " age
-assign "RawLang" to name  
-assign value to variable age as 2
-call function print_message with arguments name and age 
-call function calculate with arguments 2 3 4 
-```
-
-```
-Must write Language should be languageName on the top of the file 
-```
-
-## Output in python
-You will get the output in a newly generated directory in the 'RawLang' folder named 'generated_code' and the file name will be the same as the code.txt with the appropriate extension of the language you have written in the top of the file.
-
-```py
-name = "RawLang"
-age = 19
-def calculate(x, y, z):
-    sum = x + y - z
-    return sum
-
-def print_message(name, age):
-    print("Hello" + name)
-    print("Your age is " + age)
-
-name = "RawLang"
-age = 2
-
-print_message(name, age)
-calculate(2, 3, 4)
-
-
-```
-## Language syntax and keywords
-[Docs](https://github.com/Kashina69/RawLang/blob/main/Syntax%20and%20keywords.md)
-
-## Languages available now 
 - Python
-- Javascript
-- Golang
+- JavaScript
+- Go
 - Rust
 
-## Contributing
-Contributions are welcome! Feel free to submit bug reports, feature requests, or pull requests to help RawLang improve.
-Plzz don't contribute in readme.md its already good 
+It is designed for fast prototyping while still allowing **manual code injection** using fenced code blocks (``` ... ```).
+
+## What is improved in this version
+
+- A shared parser is used for all target languages for consistent behavior.
+- The CLI no longer computes every language generator per run (faster conversion path).
+- Generators now support a broader set of common language features.
+- Added support for manual/real-code blocks inside RawLang files.
+- Clear, practical documentation and examples.
+
+## Install / Run
+
+```bash
+python main.py <path-to-file.rl>
+```
+
+Example:
+
+```bash
+python main.py ./main.rl
+```
+
+Generated files are written to `generated_code/` using the source file name and target extension.
+
+## Required file header
+
+Every `.rl` file must start with:
+
+```rawlang
+language should be python
+```
+
+Supported values: `python`, `javascript`, `golang`, `rust`.
+
+---
+
+## RawLang syntax guide
+
+### 1) Variables
+
+```rawlang
+make score = 10
+make name = "RawLang"
+assign 20 to score
+```
+
+### 2) Lists, sets, tuples, objects
+
+```rawlang
+make list nums = 1 2 3 4
+make set tags = "dev" "tools"
+make tuple pair = 10 20
+make object user = name "Raw" age 19
+```
+
+### 3) Print
+
+```rawlang
+print "hello"
+prints score
+```
+
+### 4) Functions + return
+
+```rawlang
+create function add with parameters x, y which
+print x + y
+return x + y
+.
+```
+
+Use `.` to close the current block in indentation-sensitive output (especially Python generation).
+
+### 5) Function calls
+
+```rawlang
+call add with arguments 5, 6
+```
+
+### 6) Conditions
+
+```rawlang
+check if score > 10
+print "high"
+otherwise if score == 10
+print "equal"
+otherwise
+print "low"
+.
+```
+
+### 7) Loops
+
+Range loop:
+
+```rawlang
+loop i from 0 to 10
+print i
+.
+```
+
+For-each loop:
+
+```rawlang
+loop for item in nums
+print item
+.
+```
+
+---
+
+## Manual code blocks (real code)
+
+You can embed direct target-language code:
+
+````rawlang
+```python
+print("manual python block")
+```
+````
+
+Rules:
+
+- ` ```python `, ` ```javascript `, ` ```golang `, ` ```rust ` only pass through when the selected target matches.
+- Plain ` ``` ` (no language tag), ` ```code `, ` ```real code `, or ` ```manual ` passes through for any target.
+
+This gives you a safe fallback for advanced cases the parser doesn't yet cover.
+
+---
+
+## End-to-end example
+
+Input (`example.rl`):
+
+````rawlang
+language should be javascript
+make value = 3
+create function show with parameters x which
+print x
+.
+call show with arguments value
+```javascript
+console.log("custom JS tail");
+```
+````
+
+Output (`generated_code/example.js`) will include both generated JS and your manual block.
+
+---
+
+## Project structure
+
+- `main.py` — CLI entry point and file orchestration.
+- `code_generators/common.py` — shared parser and normalized statements.
+- `code_generators/python/python_code_generator.py` — Python emitter.
+- `code_generators/javascript/javascript_code_generator.py` — JavaScript emitter.
+- `code_generators/go_lang/go_lang_code_generator.py` — Go emitter.
+- `code_generators/rust/rust_code_generator.py` — Rust emitter.
+
+## Notes / limitations
+
+- Rust and Go output is best-effort for generic typing scenarios.
+- For highly language-specific constructs, use manual fenced blocks.
+- Keep expressions explicit in RawLang (e.g., `x + y`, `name == "a"`) for predictable conversion.
 
 ## License
-This project is licensed under the MIT License.
 
-## Developer 
-Prince Rawat AKA Kashina 
+MIT

--- a/Syntax and keywords.md
+++ b/Syntax and keywords.md
@@ -1,128 +1,94 @@
-# RawLang 
+# RawLang Syntax and Keywords
 
-### Use . go out of the function or loop or condition scope 
-### For next line just use next line 
+## Header
 
-## Output programming language
-
+```rawlang
+language should be python
 ```
-language should be python 
-language should be javascript
-language should be golang
-language should be rust 
+
+Supported targets:
+- python
+- javascript
+- golang
+- rust
+
+## Core statements
+
+### Variables
+```rawlang
+make x = 10
+assign 42 to x
 ```
+
+### Collections
+```rawlang
+make list nums = 1 2 3
+make set tags = "a" "b"
+make tuple pair = 1 2
+make object user = name "Raw" age 19
+```
+
+### Print
+```rawlang
+print "hello"
+prints x
+```
+
+### Function
+```rawlang
+create function add with parameters x, y which
+return x + y
+.
+```
+
+### Call
+```rawlang
+call add with arguments 10, 20
+```
+
+### Condition
+```rawlang
+check if x > 10
+print "big"
+otherwise if x == 10
+print "equal"
+otherwise
+print "small"
+.
+```
+
+### Loops
+```rawlang
+loop i from 0 to 5
+print i
+.
+
+loop for item in nums
+print item
+.
+```
+
 ## Comments
-```
-// comment
-```
-## Take input
-```python 
-take input
-```
-## Variable declaration
-``` python
-make variableName = 5 variableName2 = 10 variableName3 = 15
-make userInput which takes input with message "Enter your name:"
-make userNumber which takes number input with message "Give number:"
-``` 
 
-## Assign variable 
-``` python
-assign 5 to variableName
-assign outputVariableName to variableName
+```rawlang
+# python style
+// c style
 ```
 
-## List or Array
-``` python
-make (list or array or arr or lst) listName = 10 15 20 30 35 "name" age "class"
+## Manual code blocks
 
-```
+Use fenced blocks for direct code passthrough:
 
-## Dictionary or Object
-
-``` python
-make (dictionary or dict or object or obj  ) dictionaryName with values key1 = value1, key2 = value2, key3 = value3 and key4 = value4 .
-make (dictionary or dict or object or obj  ) dictionaryName with values [key1 = value1, key2 = value2, key3 = value3 and key4 = value4] .
-make (dictionary or dict or object or obj  ) dictionaryName = key1 = value1, key2 = value2, key3 = value3 and key4 = value4 .
-make (dictionary or dict or object or obj  ) dictionaryName = [key1 = value1, key2 = value2, key3 = value3 and key4 = value4] .
-``` 
-
-# Make Function
-``` python
-create (function or fun or func) functionName with (parameters or parms) parameter1, parameter2 and parameter3 which 
-    prints parameter1 + parameter2 + parameter3
-    prints parameter1 - parameter2 - parameter3
-    prints parameter1 * parameter2 * parameter3
-    prints parameter1 / parameter2 / parameter3
-    prints parameter1 % parameter2 % parameter3
-    prints parameter1 ** parameter2 ** parameter3
-    prints parameter1 // parameter2 // parameter3
-    return "all good"
-
-                                # or 
-
-create functionName with parameter1, parameter2 and parameter3 as (parameters or parms) which 
-    prints parameter1
-    prints parameter2
-    prints parameter3
-
-```
-
-# Call Function
-``` python
-call functionName with (arguments, args) argument1, argument2 and argument3 then assign the output to outputVariableName
-
-make variableName which call functionName with argument1, argument2 and argument3 (arguments, args) 
-
-functionName(argument1, argument2 and argument3)
-```
-
-# Condition
-``` python
-create functionName with parms num1 and num2 which checks if num1 (is greater than or > )num2 then prints "num1 is greater than num2"
-(else or otherwise) if num1 (is or == ) num2 then prints "num1 is equal to num2"
-(else or otherwise) if num1 (is not or != ) num2 then prints "num1 is not equal to num2"
-(else or otherwise) prints "Can't tell"
-```
-- ## Condition keyword
+````rawlang
 ```python
-condition_words_dict = {
-    "is": "==",
-    "else": "else",
-    "and": "and",
-    "or": "or",
-    "not": "not",
-    "is not": "!=",
-    "greater than": ">",
-    "less than": "<",
-    "greater than equal to": ">=",
-    "less than equal to": "<=",
-}
+print("real python code")
 ```
+````
 
-## Loops
-``` python
-loop from 1 to 10 then prints "Hello World"
+Accepted tags:
+- target-specific: `python`, `javascript`, `golang`, `rust`
+- generic passthrough: no tag, `code`, `real code`, `manual`
 
-loop while condition is true then prints "Hello World"
+## Scope closing
 
-```
-
-## Loop List Array
-
-```python
-loop for item in listName then prints item
-                    or 
-loop listName for item then prints item
-```
-## Loop Dictionary or list  Array
-```python
-loop for key and value in dict_name then prints key and value
-                    or
-loop dict_name for key, value then prints key and value
-```
-
-## Normal code 
-```
-for custom code write \`\`\` Normal code \`\`\`
-```
+Use a single line with `.` to close a block when needed.

--- a/code_generators/common.py
+++ b/code_generators/common.py
@@ -1,0 +1,211 @@
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+BLOCK_STARTERS = ("if", "elif", "else", "for", "while", "function")
+
+
+@dataclass
+class Statement:
+    kind: str
+    text: str = ""
+    condition: str = ""
+    name: str = ""
+    args: List[str] | None = None
+    target: str = ""
+    start: str = ""
+    end: str = ""
+    iterable: str = ""
+    var: str = ""
+    raw_lines: List[str] | None = None
+
+
+def split_csv(raw: str) -> List[str]:
+    cleaned = raw.replace(" and ", ", ")
+    return [item.strip() for item in cleaned.split(",") if item.strip()]
+
+
+def normalize_value(token: str) -> str:
+    token = token.strip()
+    if token.lower() in {"true", "false", "none", "null"}:
+        return {"none": "None", "null": "None"}.get(token.lower(), token.lower().capitalize())
+    if re.fullmatch(r"-?\d+(\.\d+)?", token):
+        return token
+    if token.startswith(('"', "'")) and token.endswith(('"', "'")):
+        return token
+    return token
+
+
+def _extract_params(rest: str) -> List[str]:
+    if "with parameters" in rest:
+        raw = rest.split("with parameters", 1)[1]
+    elif "with parameter" in rest:
+        raw = rest.split("with parameter", 1)[1]
+    elif "with parms" in rest:
+        raw = rest.split("with parms", 1)[1]
+    else:
+        return []
+    raw = raw.replace("which", "").strip()
+    return split_csv(raw)
+
+
+def parse_rawlang(english_code: str, language: str) -> List[Statement]:
+    statements: List[Statement] = []
+    lines = english_code.splitlines()
+    i = 0
+    while i < len(lines):
+        raw = lines[i].rstrip()
+        stripped = raw.strip()
+
+        if not stripped:
+            statements.append(Statement(kind="blank"))
+            i += 1
+            continue
+
+        if stripped == ".":
+            statements.append(Statement(kind="dedent"))
+            i += 1
+            continue
+
+        if stripped.startswith("```"):
+            fence = stripped[3:].strip().lower()
+            raw_lines: List[str] = []
+            i += 1
+            while i < len(lines):
+                if lines[i].strip() == "```":
+                    break
+                raw_lines.append(lines[i])
+                i += 1
+            include = not fence or fence in {"real code", "code", language, "manual"}
+            if include:
+                statements.append(Statement(kind="raw", raw_lines=raw_lines))
+            i += 1
+            continue
+
+        lower = stripped.lower()
+
+        if lower.startswith("#") or lower.startswith("//"):
+            statements.append(Statement(kind="comment", text=stripped.lstrip("#/ ")))
+            i += 1
+            continue
+
+        if lower.startswith("make list ") or lower.startswith("make array ") or lower.startswith("make arr ") or lower.startswith("make lst "):
+            rest = stripped.split(maxsplit=2)[2]
+            name, values = rest.split("=", 1)
+            vals = [normalize_value(v) for v in values.split()]
+            statements.append(Statement(kind="assign", target=name.strip(), text="[" + ", ".join(vals) + "]"))
+            i += 1
+            continue
+
+        if lower.startswith("make set "):
+            rest = stripped.split(maxsplit=2)[2]
+            name, values = rest.split("=", 1)
+            vals = [normalize_value(v) for v in values.split()]
+            statements.append(Statement(kind="assign", target=name.strip(), text="{" + ", ".join(vals) + "}"))
+            i += 1
+            continue
+
+        if lower.startswith("make tuple "):
+            rest = stripped.split(maxsplit=2)[2]
+            name, values = rest.split("=", 1)
+            vals = [normalize_value(v) for v in values.split()]
+            trailing = "," if len(vals) == 1 else ""
+            statements.append(Statement(kind="assign", target=name.strip(), text="(" + ", ".join(vals) + trailing + ")"))
+            i += 1
+            continue
+
+        if lower.startswith("make object ") or lower.startswith("make dict ") or lower.startswith("make dictionary "):
+            rest = stripped.split(maxsplit=2)[2]
+            name, values = rest.split("=", 1)
+            parts = values.split()
+            kv = []
+            for idx in range(0, len(parts) - 1, 2):
+                k = parts[idx]
+                v = normalize_value(parts[idx + 1])
+                kv.append(f'"{k}": {v}')
+            statements.append(Statement(kind="assign", target=name.strip(), text="{" + ", ".join(kv) + "}"))
+            i += 1
+            continue
+
+        if lower.startswith("make ") and "=" in stripped:
+            rest = stripped[5:]
+            chunks = re.split(r"\s+(?=[A-Za-z_]\w*\s*=)", rest)
+            for chunk in chunks:
+                if "=" in chunk:
+                    target, expr = chunk.split("=", 1)
+                    statements.append(Statement(kind="assign", target=target.strip(), text=expr.strip()))
+            i += 1
+            continue
+
+        if lower.startswith("assign ") and " to " in lower:
+            after = stripped[7:]
+            expr, target = re.split(r"\bto\b", after, maxsplit=1, flags=re.IGNORECASE)
+            target = target.replace("variable", "").replace("as", "").strip()
+            statements.append(Statement(kind="assign", target=target, text=expr.strip()))
+            i += 1
+            continue
+
+        if lower.startswith("print ") or lower.startswith("prints "):
+            text = stripped.split(maxsplit=1)[1]
+            statements.append(Statement(kind="print", text=text))
+            i += 1
+            continue
+
+        if lower.startswith("create function ") or lower.startswith("create func ") or lower.startswith("create fun "):
+            name = stripped.split()[2]
+            params = _extract_params(lower)
+            statements.append(Statement(kind="function", name=name, args=params))
+            i += 1
+            continue
+
+        if lower.startswith("return "):
+            statements.append(Statement(kind="return", text=stripped[7:]))
+            i += 1
+            continue
+
+        if lower.startswith("call "):
+            if "with arguments" in lower:
+                name = stripped.split()[1]
+                args = split_csv(stripped.lower().split("with arguments", 1)[1])
+                statements.append(Statement(kind="expr", text=f"{name}({', '.join(args)})"))
+            else:
+                statements.append(Statement(kind="expr", text=stripped[5:]))
+            i += 1
+            continue
+
+        if lower.startswith("check if "):
+            statements.append(Statement(kind="if", condition=stripped[9:]))
+            i += 1
+            continue
+
+        if lower.startswith("otherwise check if ") or lower.startswith("otherwise if "):
+            cond = re.sub(r"^otherwise\s+(check\s+)?if\s+", "", stripped, flags=re.IGNORECASE)
+            statements.append(Statement(kind="elif", condition=cond))
+            i += 1
+            continue
+
+        if lower == "otherwise" or lower == "else":
+            statements.append(Statement(kind="else"))
+            i += 1
+            continue
+
+        if lower.startswith("loop ") and " from " in lower and " to " in lower:
+            m = re.match(r"loop\s+([A-Za-z_]\w*)?\s*from\s+(.+?)\s+to\s+(.+)$", stripped, flags=re.IGNORECASE)
+            if m:
+                var = m.group(1) or "i"
+                statements.append(Statement(kind="for_range", var=var, start=m.group(2).strip(), end=m.group(3).strip()))
+                i += 1
+                continue
+
+        if lower.startswith("loop for ") and " in " in lower:
+            m = re.match(r"loop\s+for\s+([A-Za-z_]\w*)\s+in\s+(.+)$", stripped, flags=re.IGNORECASE)
+            if m:
+                statements.append(Statement(kind="for_each", var=m.group(1), iterable=m.group(2).strip()))
+                i += 1
+                continue
+
+        statements.append(Statement(kind="expr", text=stripped))
+        i += 1
+
+    return statements

--- a/code_generators/go_lang/go_lang_code_generator.py
+++ b/code_generators/go_lang/go_lang_code_generator.py
@@ -1,2 +1,60 @@
-def generate_golang_code(english_code):
-    return "generated code"
+from code_generators.common import parse_rawlang
+
+
+def generate_golang_code(english_code: str) -> str:
+    statements = parse_rawlang(english_code, "golang")
+    body: list[str] = []
+    indent = 1
+
+    def line(txt: str) -> None:
+        body.append("\t" * indent + txt)
+
+    for st in statements:
+        if st.kind == "blank":
+            body.append("")
+        elif st.kind == "dedent":
+            if indent > 1:
+                indent -= 1
+                body.append("\t" * indent + "}")
+        elif st.kind == "comment":
+            line(f"// {st.text}")
+        elif st.kind == "assign":
+            line(f"{st.target} := {st.text}")
+        elif st.kind == "print":
+            line(f"fmt.Println({st.text})")
+        elif st.kind == "function":
+            params = ", ".join(f"{p} interface{{}}" for p in (st.args or []))
+            line(f"func {st.name}({params}) interface{{}} {{")
+            indent += 1
+        elif st.kind == "return":
+            line(f"return {st.text}")
+        elif st.kind == "if":
+            line(f"if {st.condition} {{")
+            indent += 1
+        elif st.kind == "elif":
+            indent = max(1, indent - 1)
+            line(f"}} else if {st.condition} {{")
+            indent += 1
+        elif st.kind == "else":
+            indent = max(1, indent - 1)
+            line("} else {")
+            indent += 1
+        elif st.kind == "for_range":
+            line(f"for {st.var} := {st.start}; {st.var} < {st.end}; {st.var}++ {{")
+            indent += 1
+        elif st.kind == "for_each":
+            line(f"for _, {st.var} := range {st.iterable} {{")
+            indent += 1
+        elif st.kind == "raw":
+            body.extend(st.raw_lines or [])
+        else:
+            line(st.text)
+
+    while indent > 1:
+        indent -= 1
+        body.append("\t" * indent + "}")
+
+    out = ["package main", "", 'import "fmt"', "", "func main() {"]
+    out.extend(body)
+    out.append("}")
+    return "\n".join(out).rstrip() + "\n"

--- a/code_generators/javascript/javascript_code_generator.py
+++ b/code_generators/javascript/javascript_code_generator.py
@@ -1,2 +1,56 @@
-def generate_javascript_code(english_code):
-    return "generated code"
+from code_generators.common import parse_rawlang
+
+
+def generate_javascript_code(english_code: str) -> str:
+    statements = parse_rawlang(english_code, "javascript")
+    out: list[str] = []
+    indent = 0
+
+    def line(txt: str) -> None:
+        out.append("    " * indent + txt)
+
+    for st in statements:
+        if st.kind == "blank":
+            out.append("")
+        elif st.kind == "dedent":
+            if indent > 0:
+                indent -= 1
+                out.append("    " * indent + "}")
+        elif st.kind == "comment":
+            line(f"// {st.text}")
+        elif st.kind == "assign":
+            line(f"let {st.target} = {st.text};")
+        elif st.kind == "print":
+            line(f"console.log({st.text});")
+        elif st.kind == "function":
+            params = ", ".join(st.args or [])
+            line(f"function {st.name}({params}) {{")
+            indent += 1
+        elif st.kind == "return":
+            line(f"return {st.text};")
+        elif st.kind == "if":
+            line(f"if ({st.condition}) {{")
+            indent += 1
+        elif st.kind == "elif":
+            indent = max(0, indent - 1)
+            line(f"}} else if ({st.condition}) {{")
+            indent += 1
+        elif st.kind == "else":
+            indent = max(0, indent - 1)
+            line("} else {")
+            indent += 1
+        elif st.kind == "for_range":
+            line(f"for (let {st.var} = {st.start}; {st.var} < {st.end}; {st.var}++) {{")
+            indent += 1
+        elif st.kind == "for_each":
+            line(f"for (const {st.var} of {st.iterable}) {{")
+            indent += 1
+        elif st.kind == "raw":
+            out.extend(st.raw_lines or [])
+        else:
+            line(st.text.rstrip(";") + ";")
+
+    while indent > 0:
+        indent -= 1
+        out.append("    " * indent + "}")
+    return "\n".join(out).rstrip() + "\n"

--- a/code_generators/python/python_code_generator.py
+++ b/code_generators/python/python_code_generator.py
@@ -1,183 +1,53 @@
-from . import generator
-# import generator
-import re
-
-def tokenizer(english_code):
-    # Split the input string into lines
-    lines = english_code.strip().split('\n')
-    
-    # Regular expression to split on any whitespace
-    token_pattern = re.compile(r'\s+')
-    
-    # List to hold the tokenized lines
-    tokenized_lines = []
-    
-    for line in lines:
-        # Remove comments (assuming comments start with #)
-        # line = re.split(r'#', line)[0].strip()
-        
-        # Split line into tokens based on whitespace
-        tokens = token_pattern.split(line)
-        
-        # Remove empty tokens
-        tokens = [token for token in tokens if token]
-        
-        # Add list of tokens to tokenized_lines
-        tokenized_lines.append(tokens)
-    
-    return tokenized_lines
+from code_generators.common import parse_rawlang
 
 
-def convert_line_to_code(line):
-    if not line:  # Check if the line is empty
-        return ""
+def generate_python_code(english_code: str) -> str:
+    statements = parse_rawlang(english_code, "python")
+    out: list[str] = []
+    indent = 0
 
-    # Check the first token to determine the type of operation
-    operation = line[0].lower()
+    for st in statements:
+        if st.kind == "blank":
+            out.append("")
+            continue
+        if st.kind == "dedent":
+            indent = max(0, indent - 1)
+            continue
 
-    # Depending on the operation, generate corresponding Python code
-    if operation == "make":
-        if line[1] in ["list", "array", "arr", "lst"]:
-            return generator.make_array(line[2:])
-        elif line[1] == "set":
-            return generator.make_set(line[2:])
-        elif line[1] == "tuple":
-            return generator.make_tuple(line[2:])
-        elif line[1] in ["dictionary", "dict", "object", "obj"]:
-            return generator.make_object(line[2:])
+        if st.kind == "elif" or st.kind == "else":
+            indent = max(0, indent - 1)
+
+        prefix = "    " * indent
+        if st.kind == "comment":
+            out.append(f"{prefix}# {st.text}")
+        elif st.kind == "assign":
+            out.append(f"{prefix}{st.target} = {st.text}")
+        elif st.kind == "print":
+            out.append(f"{prefix}print({st.text})")
+        elif st.kind == "function":
+            params = ", ".join(st.args or [])
+            out.append(f"{prefix}def {st.name}({params}):")
+            indent += 1
+        elif st.kind == "return":
+            out.append(f"{prefix}return {st.text}")
+        elif st.kind == "if":
+            out.append(f"{prefix}if {st.condition}:")
+            indent += 1
+        elif st.kind == "elif":
+            out.append(f"{prefix}elif {st.condition}:")
+            indent += 1
+        elif st.kind == "else":
+            out.append(f"{prefix}else:")
+            indent += 1
+        elif st.kind == "for_range":
+            out.append(f"{prefix}for {st.var} in range({st.start}, {st.end}):")
+            indent += 1
+        elif st.kind == "for_each":
+            out.append(f"{prefix}for {st.var} in {st.iterable}:")
+            indent += 1
+        elif st.kind == "raw":
+            out.extend(st.raw_lines or [])
         else:
-            return generator.make_variable(line[1:])
+            out.append(f"{prefix}{st.text}")
 
-    elif operation == "create":
-        if line[1].lower() in ["function", "def", "func", "fun"]:
-            return generator.make_function(line[2:])
-        else:
-            return "Invalid function creation syntax"
-
-    elif operation == "call":
-    # Check if "with" and "arguments" are in the expected positions
-        if len(line) < 5 or line[2].lower() != "with" or line[3].lower() not in ["args", "arg", "argument", "arguments"]:
-            return f"Syntax error in call statement: {' '.join(line)}"
-        else:
-            return f"{line[1]}({', '.join(line[4:])})"
-
-
-    elif operation in ["print", "prints"]:
-        arguments = ' '.join(line[1:])
-        return f'print({arguments})'
-
-    elif operation == "check":
-        if line[1].lower() == "if":
-            condition = ' '.join(line[2:])
-        else:
-            condition = ' '.join(line[1:])
-        return f'if {condition}:'
-
-    elif operation in ["else", "otherwise"]:
-        if len(line) > 1 and line[1].lower() == "check":
-            if len(line) > 2 and line[2].lower() == "if":
-                condition = ' '.join(line[3:])
-                return f'elif {condition}:'
-            else:
-                condition = ' '.join(line[2:])
-                return f'elif {condition}:'
-        if len(line) > 1 and line[1].lower() == "if":
-            condition = ' '.join(line[2:])
-            return f'elif {condition}:'
-        else:
-            return 'else:'
-
-    elif operation == "loop":
-        loop_variable = line[1]
-        range_start = line[3]
-        range_end = line[5]
-        return f'for {loop_variable} in range({range_start}, {range_end}):'
-
-    elif operation == "return":
-        return f'return {" ".join(line[1:])}'
-
-    elif operation[0] == "#":
-        return f'# {' '.join(line[1:])}'
-
-    else:
-        return f"What the hell you wrote {line[0]}"
-
-    # Ensure function always returns a string
-    return ""
-
-def generate_python_code(english_code):
-    # Ensure `generated_code` is initialized
-    generated_code = "" 
-    tokenized_code = tokenizer(english_code)
-    indent_level = 0
-
-    for line in tokenized_code:
-        generated_line = convert_line_to_code(line)
-        if line == []:
-            indent_level = 0
-        # Adjust indent level based on the operation
-        if generated_line.endswith(":"):
-            generated_code += '    ' * indent_level + generated_line + '\n'
-            indent_level += 1
-        elif generated_line == 'else:':
-            indent_level -= 1
-            generated_code += '    ' * indent_level + generated_line + '\n'
-            indent_level += 1
-        elif generated_line.startswith("return"):
-            generated_code += '    ' * indent_level + generated_line + '\n'
-            indent_level -= 1
-        else:
-            generated_code += '    ' * indent_level + generated_line + '\n'
-    # print(generated_code)
-    return generated_code
-
-# Example usage
-english_code = """
-# Variable assignment
-make variableName = 5
-make variableName2 = 10
-make variableName3 = 15
-
-make set setName = prince rawat ji 69 @ 
-make list listName = prince rawat ji 69 @ 
-make tuple tupleName = prince rawat ji 69 @ 
-
-make object people = name prince lastname rawat class 12
-
-loop list from 1 to 20
-print "Hello niggas"
-
-# Taking input with a message
-make userInput which takes input with message "Enter your name:"
-make userNumber which takes number input with message "Give number:"
-
-# Function definition
-create func calculate with parameters x y z which 
-    prints x + y + z
-    prints x - y - z
-    prints x * y * z
-    prints x / y / z
-    prints x % y % z
-    prints x ** y ** z
-    prints x // y // z
-    return "all good"
-
-# Function call
-call calculate with arguments variableName variableName2 variableName3
-
-# Conditional statements
-check if variableName == 5
-    print "variableName is 5"
-
-otherwise check if variableName2 == 10
-    print "variableName2 is 10"
-
-otherwise if variableName3 == 15
-    print "variableName3 is 15"
-    
-otherwise
-    print "None of the conditions are met"
-
-# this is a buttifyl comment  
-"""
-generate_python_code(english_code)
+    return "\n".join(out).rstrip() + "\n"

--- a/code_generators/rust/rust_code_generator.py
+++ b/code_generators/rust/rust_code_generator.py
@@ -1,2 +1,60 @@
-def generate_rust_code(english_code):
-    return "generated code"
+from code_generators.common import parse_rawlang
+
+
+def generate_rust_code(english_code: str) -> str:
+    statements = parse_rawlang(english_code, "rust")
+    body: list[str] = []
+    indent = 1
+
+    def line(txt: str) -> None:
+        body.append("    " * indent + txt)
+
+    for st in statements:
+        if st.kind == "blank":
+            body.append("")
+        elif st.kind == "dedent":
+            if indent > 1:
+                indent -= 1
+                body.append("    " * indent + "}")
+        elif st.kind == "comment":
+            line(f"// {st.text}")
+        elif st.kind == "assign":
+            line(f"let mut {st.target} = {st.text};")
+        elif st.kind == "print":
+            line(f"println!(\"{{:?}}\", {st.text});")
+        elif st.kind == "function":
+            params = ", ".join(f"{p}: i64" for p in (st.args or []))
+            line(f"fn {st.name}({params}) -> i64 {{")
+            indent += 1
+        elif st.kind == "return":
+            line(f"return {st.text};")
+        elif st.kind == "if":
+            line(f"if {st.condition} {{")
+            indent += 1
+        elif st.kind == "elif":
+            indent = max(1, indent - 1)
+            line(f"}} else if {st.condition} {{")
+            indent += 1
+        elif st.kind == "else":
+            indent = max(1, indent - 1)
+            line("} else {")
+            indent += 1
+        elif st.kind == "for_range":
+            line(f"for {st.var} in {st.start}..{st.end} {{")
+            indent += 1
+        elif st.kind == "for_each":
+            line(f"for {st.var} in {st.iterable} {{")
+            indent += 1
+        elif st.kind == "raw":
+            body.extend(st.raw_lines or [])
+        else:
+            line(st.text.rstrip(";") + ";")
+
+    while indent > 1:
+        indent -= 1
+        body.append("    " * indent + "}")
+
+    out = ["fn main() {"]
+    out.extend(body)
+    out.append("}")
+    return "\n".join(out).rstrip() + "\n"

--- a/main.py
+++ b/main.py
@@ -1,85 +1,75 @@
-import sys
 import os
-from code_generators.python.python_code_generator import generate_python_code
-from code_generators.javascript.javascript_code_generator import generate_javascript_code
+import sys
+from typing import Callable
+
 from code_generators.go_lang.go_lang_code_generator import generate_golang_code
+from code_generators.javascript.javascript_code_generator import generate_javascript_code
+from code_generators.python.python_code_generator import generate_python_code
 from code_generators.rust.rust_code_generator import generate_rust_code
 
 
-def checkProgrammingLanguage(first_line):
+SUPPORTED_LANGUAGES = {
+    "python": ("py", generate_python_code),
+    "javascript": ("js", generate_javascript_code),
+    "golang": ("go", generate_golang_code),
+    "rust": ("rs", generate_rust_code),
+}
+
+
+def check_programming_language(first_line: str) -> str | None:
     words = first_line.lower().split()
-    if words[0] == "language":
+    if len(words) >= 2 and words[0] == "language":
         lang = words[-1]
-        if lang in ["python", "javascript", "golang", "rust"]:
+        if lang in SUPPORTED_LANGUAGES:
             return lang
-    print("Broo at least tell the language")
-    print("This is how to do it")
-    print("Write:")
-    print("language should be python or javascript or go or rust")
-    print("On the top of the file")
+    print("Language not set correctly.")
+    print("Use one of these headers at the top of your .rl file:")
+    print("language should be python | javascript | golang | rust")
     return None
-            
-def code_generator(language, english_code):
-    code_generator_dict = {
-        "python": generate_python_code(english_code),
-        "javascript": generate_javascript_code(english_code),
-        "golang": generate_golang_code(english_code),
-        "rust": generate_rust_code(english_code)
-    }
-    return code_generator_dict[language]
-    
-def check_file_extension(language):
-    file_extension_dict ={
-        "python": "py",
-        "javascript": "js",
-        "golang": "go",
-        "rust": "rs"
-    }
-    return file_extension_dict[language]
-
-def write_in_file(generated_code,file_extension,input_filename):
-# Create a directory to store generated code if it doesn't exist
-        output_directory = "generated_code"
-        if not os.path.exists(output_directory):
-            os.makedirs(output_directory)
-
-# Split the input filename and extension
-        filename, _ = os.path.splitext(input_filename)
-# Concatenate the output filename with the proper file extension
-        output_filename = os.path.join(output_directory, filename + "." + file_extension)
-        with open(output_filename, 'w') as file:
-            file.write(generated_code)
-        print("Code generated successfully and saved in", output_filename)
 
 
+def generate_code(language: str, english_code: str) -> str:
+    _, generator = SUPPORTED_LANGUAGES[language]
+    return generator(english_code)
 
-def main():
-    # Check if filename is provided as command-line argument
+
+def write_in_file(generated_code: str, file_extension: str, input_filename: str) -> str:
+    output_directory = "generated_code"
+    os.makedirs(output_directory, exist_ok=True)
+
+    filename = os.path.splitext(os.path.basename(input_filename))[0]
+    output_filename = os.path.join(output_directory, f"{filename}.{file_extension}")
+
+    with open(output_filename, "w", encoding="utf-8") as file:
+        file.write(generated_code)
+
+    return output_filename
+
+
+def main() -> None:
     if len(sys.argv) != 2:
-        print("Bro atleast give a file to work on")
+        print("Usage: python main.py <rawlang_file>")
         return
+
     input_filename = sys.argv[1]
     try:
-        with open(input_filename, 'r') as file:
-# check programming language
+        with open(input_filename, "r", encoding="utf-8") as file:
             first_line = file.readline()
-            language = checkProgrammingLanguage(first_line)
-            if language:
-                print("Programming language set to:", language)
-# read english code
-                english_code = file.read()
-                generated_code = code_generator(language, english_code)
-                file_extension = check_file_extension(language)
-# write code in file 
-                write_in_file(generated_code, file_extension, input_filename)
-            else:
+            language = check_programming_language(first_line)
+            if not language:
                 return
+
+            english_code = file.read()
+            generated_code = generate_code(language, english_code)
+            file_extension, _ = SUPPORTED_LANGUAGES[language]
+            output_filename = write_in_file(generated_code, file_extension, input_filename)
+            print(f"Programming language set to: {language}")
+            print(f"Code generated successfully and saved in {output_filename}")
     except FileNotFoundError:
-        print("File not found:", input_filename)
-    except Exception as e:
-        print("An error occurred:", str(e))
+        print(f"File not found: {input_filename}")
+    except Exception as error:  # noqa: BLE001
+        print(f"An error occurred: {error}")
+
 
 if __name__ == "__main__":
     main()
-
-


### PR DESCRIPTION
### Motivation
- Provide a single, robust parser so all language backends behave consistently and support more RawLang constructs.
- Improve emitted code quality across Python, JavaScript, Go, and Rust while keeping a fast CLI by only generating the requested target.
- Allow manual passthrough of real/target-specific code blocks to cover edge cases not yet handled by the parser.

### Description
- Add `code_generators/common.py`: a shared `parse_rawlang` parser that normalizes RawLang into `Statement` objects (assign, function, if/elif/else, loops, print, raw fenced blocks, dedent via `.`). 
- Rework emitters to consume the shared AST: `code_generators/python/python_code_generator.py`, `code_generators/javascript/javascript_code_generator.py`, `code_generators/go_lang/go_lang_code_generator.py`, and `code_generators/rust/rust_code_generator.py` now emit idiomatic target code and correctly handle block opening/closing and fenced manual blocks.
- Simplify and optimize CLI in `main.py` with `SUPPORTED_LANGUAGES` mapping, lazy per-language generation via `generate_code`, safer file IO in `write_in_file`, and clearer header validation via `check_programming_language`.
- Improve docs and references: `README.md` rewritten with examples, manual-code-block rules, and usage; `Syntax and keywords.md` updated to match the new parser and accepted statements/blocks.

### Testing
- Ran static compile checks with `python -m py_compile` on `main.py` and all updated generator modules; compilation succeeded.
- Executed end-to-end conversions for sample files using `python main.py /tmp/sample_python.rl`, `/tmp/sample_js.rl`, `/tmp/sample_go.rl`, and `/tmp/sample_rust.rl`, and verified generated outputs in `generated_code/` for each target; all runs completed successfully and generated valid-looking output files.
- Verified manual fenced passthrough by including a target-specific fenced block (e.g., ```python``` / ```javascript```) in samples and confirming the block appears verbatim in the generated file; this behavior worked as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c390ad272883268816dc18610102e0)